### PR TITLE
Fix typo in client side mod database

### DIFF
--- a/mods/src/main/java/de/markusbordihn/minecraft/adaptiveperformancetweaksmods/config/ModsDatabase.java
+++ b/mods/src/main/java/de/markusbordihn/minecraft/adaptiveperformancetweaksmods/config/ModsDatabase.java
@@ -88,7 +88,7 @@ public class ModsDatabase {
     "farsight-1.19.6.jar",
     "flickerfix-2.0.0.jar",
     "fm_audio_extension_forge_1.1.0_MC_1.19.jar",
-    "foreperson-forge-2.1.0-mc1.19.jar",
+    "firstperson-forge-2.1.0-mc1.19.jar",
     "guiclock_1.19-3.1.jar",
     "guicompass_1.19-2.2.jar",
     "guifollowers_1.19-1.9.jar",


### PR DESCRIPTION
Noticed this when I was testing some stuff on my server, and that mod wasn't getting disabled because of the typo