### PR TITLE
Fix login protection Invulnerable/Invisible flags persisting across sessions after a mid-protection disconnect

### DIFF
--- a/Common/src/main/java/de/markusbordihn/adaptiveperformancetweaks/feature/player/PlayerLoginManager.java
+++ b/Common/src/main/java/de/markusbordihn/adaptiveperformancetweaks/feature/player/PlayerLoginManager.java
@@ -85,7 +85,15 @@ public final class PlayerLoginManager {
     }
 
     log.debug("{} {}: Logged out.", LOG_PREFIX, username);
-    playerValidationList.removeIf(v -> username.equals(v.getUsername()));
+
+    Iterator<PlayerValidation> iterator = playerValidationList.iterator();
+    while (iterator.hasNext()) {
+      PlayerValidation validation = iterator.next();
+      if (username.equals(validation.getUsername())) {
+        restorePlayer(validation);
+        iterator.remove();
+      }
+    }
   }
 
   public static void handleServerTick() {


### PR DESCRIPTION
If a player disconnects while still inside the login-protection validation window (before movement or timeout clears it), the Invulnerable entity flag set by handlePlayerLoggedIn is saved into their player NBT as-is, since Entity#invulnerable is persistent vanilla state. On the next login, PlayerValidation captures this leftover flag as "wasInvulnerable=true", so restorePlayer() then treats it as pre-existing/external and never clears it again on ANY future session - leaving the player permanently invulnerable (and functionally ignored by mob AI) until manually fixed by another mod's god-mode toggle.

handlePlayerLoggedOut now restores the player's original invisible/ invulnerable state before removing their validation entry, so protection granted by this feature never survives past the session that granted it.